### PR TITLE
Add verbose logging options to story book

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -114,3 +114,23 @@ storiesOf('ChipInput', module)
   .add('controlled input', () => themed(
     <ControlledChipInput />
   ))
+  .add('uncontrolled verbose log', () => themed(
+    <ChipInput
+      defaultValue={['foo', 'bar']}
+      onChange={action('onChange')}
+      onUpdateInput={action('onUpdateInput')}
+      onRequestDelete={action('onRequestDelete')}
+      onRequestAdd={action('onRequestAdd')}
+      onTouchTap={action('onTouchTap')}
+    />
+  ))
+  .add('controlled verbose log', () => themed(
+    <ChipInput
+      value={['foo', 'bar']}
+      onChange={action('onChange')}
+      onUpdateInput={action('onUpdateInput')}
+      onRequestDelete={action('onRequestDelete')}
+      onRequestAdd={action('onRequestAdd')}
+      onTouchTap={action('onTouchTap')}
+    />
+  ))


### PR DESCRIPTION
It's sometimes useful to see items verbosely logged.

I was a little confused about the difference between "controlled" and "uncontrolled", and seeing the various events in the action logger really helped me understand both the difference in modes, as well as exactly when the various callbacks are called, and what is contained within them.

I hope this can help someone else too.