### PR TITLE
Sort properties by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ import ChipInput from 'material-ui-chip-input'
 ## Properties
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| style | `object` | | Override the inline-styles of the root element. |
+| chipRenderer | 'function' | | A function of the type `({ value, isFocused, isDisabled, handleClick, handleRequestDelete }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
+| dataSource | `array` | | Data source for auto complete. |
+| defaultValue | `string[]` | | The chips to display by default (for uncontrolled mode). |
+| disabled | `bool` | `false` | Disables the chip input if set to true. |
 | floatingLabelText | `node` | | The content of the floating label. |
 | hintText | `node` | | The hint text to display. |
-| disabled | `bool` | `false` | Disables the chip input if set to true. |
-| defaultValue | `string[]` | | The chips to display by default (for uncontrolled mode). |
 | onChange | `function` | | Callback function that is called when the chips change (in uncontrolled mode). |
-| value | `string[]` | | The chips to display (enables controlled mode if set). |
 | onRequestAdd | `function` | | Callback function that is called when a new chip was added (in controlled mode). |
 | onRequestDelete | `function` | | Callback function that is called when a new chip was removed (in controlled mode). |
-| dataSource | `array` | | Data source for auto complete. |
 | onUpdateInput | `function` | | Callback function that is called when the input changes (useful for auto complete). |
 | openOnFocus | `bool` | `false` | Opens the auto complete list on focus if set to true. |
-| chipRenderer | 'function' | | A function of the type `({ value, isFocused, isDisabled, handleClick, handleRequestDelete }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
+| style | `object` | | Override the inline-styles of the root element. |
+| value | `string[]` | | The chips to display (enables controlled mode if set). |
+
 
 Additionally, most other properties of Material UI's [Auto Complete][mui-auto-complete] and [Text Field][mui-text-field] should be supported. Please open an issue if something is missing or does not work as expected.
 


### PR DESCRIPTION
It is difficult to scan the README for properties. Seeing as this is basically the only reference material (other than the awesome live examples), sorting the properties by name might make the README easier to use.