### PR TITLE
Feature/set new chip key

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ import ChipInput from 'material-ui-chip-input'
 | errorText | `node` | | The error text to display. |
 | floatingLabelText | `node` | | The content of the floating label. |
 | hintText | `node` | | The hint text to display. |
+| newChipKeyCode | `number` | `13` | The key code used to determine when to create a new chip. |
 | onChange | `function` | | Callback function that is called when the chips change (in uncontrolled mode). |
 | onRequestAdd | `function` | | Callback function that is called when a new chip was added (in controlled mode). |
 | onRequestDelete | `function` | | Callback function that is called when a new chip was removed (in controlled mode). |
@@ -50,7 +51,6 @@ import ChipInput from 'material-ui-chip-input'
 | openOnFocus | `bool` | `false` | Opens the auto complete list on focus if set to true. |
 | style | `object` | | Override the inline-styles of the root element. |
 | value | `string[]` | | The chips to display (enables controlled mode if set). |
-| newChipKeyCode | `number` | `13` | The key code used to determine when to create a new chip. |
 
 
 Additionally, most other properties of Material UI's [Auto Complete][mui-auto-complete] and [Text Field][mui-text-field] should be supported. Please open an issue if something is missing or does not work as expected.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ import ChipInput from 'material-ui-chip-input'
 | openOnFocus | `bool` | `false` | Opens the auto complete list on focus if set to true. |
 | style | `object` | | Override the inline-styles of the root element. |
 | value | `string[]` | | The chips to display (enables controlled mode if set). |
+| newChipKeyCode | `number` | `13` | The key code used to determine when to create a new chip. |
 
 
 Additionally, most other properties of Material UI's [Auto Complete][mui-auto-complete] and [Text Field][mui-text-field] should be supported. Please open an issue if something is missing or does not work as expected.

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -230,7 +230,7 @@ class ChipInput extends React.Component {
   }
 
   handleKeyDown = (event) => {
-    if (event.keyCode === 13) { // enter
+    if (event.keyCode === this.props.newChipKeyCode) { // default 13/enter
       this.handleAddChip(event.target.value)
     } else if (event.keyCode === 8 || event.keyCode === 46) {
       if (event.target.value === '') {
@@ -517,11 +517,13 @@ ChipInput.propTypes = {
   onUpdateInput: PropTypes.func,
   openOnFocus: PropTypes.bool,
   chipRenderer: PropTypes.func,
+  newChipKeyCode: PropTypes.number,
   clearOnBlur: PropTypes.bool
 }
 
 ChipInput.defaultProps = {
   filter: AutoComplete.caseInsensitiveFilter,
+  newChipKeyCode: 13,
   clearOnBlur: true
 }
 


### PR DESCRIPTION
Allows the setting of alternative key codes for triggering the render of a new chip.

Related Issue #35 