### PR TITLE
Fix behaviour of onBlur and add an add-on-blur example to storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import ChipInput from 'material-ui-chip-input'
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | chipRenderer | `function` | | A function of the type `({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
-| clearOnBlur | `bool` | `true` | Clears the input value after the component looses focus if set to true. |
+| clearOnBlur | `bool` | `true` | If true, clears the input value after the component loses focus. |
 | dataSource | `array` | | Data source for auto complete. |
 | dataSourceConfig | `object` | | Config for objects list dataSource, e.g. `{ text: 'text', value: 'value' }`. If not specified, the `dataSource` must be a flat array of strings. |
 | defaultValue | `string[]` | | The chips to display by default (for uncontrolled mode). |
@@ -51,6 +51,7 @@ import ChipInput from 'material-ui-chip-input'
 | onRequestDelete | `function` | | Callback function that is called when a new chip was removed (in controlled mode). |
 | onTouchTap | `function` | | Callback function that is called when text input is clicked. |
 | onUpdateInput | `function` | | Callback function that is called when the input changes (useful for auto complete). |
+| onBlur | `function` | | Callback function that is called with `event` when the input loses focus, where `event.target.value` is the current value of the text input. |
 | openOnFocus | `bool` | `false` | Opens the auto complete list on focus if set to true. |
 | style | `object` | | Override the inline-styles of the root element. |
 | value | `string[]` | | The chips to display (enables controlled mode if set). |

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ import ChipInput from 'material-ui-chip-input'
 | hintText | `node` | | The hint text to display. |
 | id | `string` | _a unique id_ | The id prop for the text field, should be set to some deteministic value if you use server-side rendering. |
 | newChipKeyCodes | `number[]` | `[13]` (enter key) | The key codes used to determine when to create a new chip. |
+| onBlur | `function` | | Callback function that is called with `event` when the input loses focus, where `event.target.value` is the current value of the text input. |
 | onChange | `function` | | Callback function that is called when the chips change (in uncontrolled mode). |
 | onRequestAdd | `function` | | Callback function that is called when a new chip was added (in controlled mode). |
 | onRequestDelete | `function` | | Callback function that is called when a new chip was removed (in controlled mode). |
 | onTouchTap | `function` | | Callback function that is called when text input is clicked. |
 | onUpdateInput | `function` | | Callback function that is called when the input changes (useful for auto complete). |
-| onBlur | `function` | | Callback function that is called with `event` when the input loses focus, where `event.target.value` is the current value of the text input. |
 | openOnFocus | `bool` | `false` | Opens the auto complete list on focus if set to true. |
 | style | `object` | | Override the inline-styles of the root element. |
 | value | `string[]` | | The chips to display (enables controlled mode if set). |

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -215,13 +215,11 @@ class ChipInput extends React.Component {
   }
 
   handleInputBlur = (event) => {
-      if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
-        if (this.props.clearOnBlur) {
-          this.setState({ inputValue: '' })
-        }
-        this.setState({ isFocused: false })
-        if (this.props.onBlur) this.props.onBlur(event)
-      }
+    if (this.props.clearOnBlur) {
+      this.setState({ inputValue: '' })
+    }
+    this.setState({ isFocused: false })
+    if (this.props.onBlur) this.props.onBlur(event)
   }
 
   handleInputFocus = (event) => {

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -215,24 +215,15 @@ class ChipInput extends React.Component {
   }
 
   handleInputBlur = (event) => {
-    if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
-      if (this.props.blurBehavior || this.props.clearOnBlur) {
-        if ((this.props.blurBehavior === 'add' || this.props.blurBehavior === 'addFirstSuggestion') && event.target.value) {
-          this.handleAddChip(event.target.value)
-        }
-        this.setState({ inputValue: '' })
-      }
-      this.setState({ isFocused: false })
-      if (this.props.onBlur) this.props.onBlur(event)
-    } else if (this.props.blurBehavior === 'addFirstSuggestion' && this.autoComplete.requestsList.length !== 0) {
-      const chipIndex = parseInt(this.autoComplete.requestsList[0].value.key, 10)
-      this.handleAddChip(this.props.dataSource[chipIndex])
-      this.setState({
-        isFocused: false,
-        inputValue: ''
-      })
-      if (this.props.onBlur) this.props.onBlur(event)
+    if (this.props.onBlur) {
+      this.props.onBlur(event)
     }
+    if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
+        if (this.props.clearOnBlur) {
+          this.setState({ inputValue: '' })
+        }
+        this.setState({ isFocused: false })
+      }
   }
 
   handleInputFocus = (event) => {
@@ -379,7 +370,6 @@ class ChipInput extends React.Component {
       id,
       inputStyle,
       clearOnBlur,
-      blurBehavior,
       onBlur, // eslint-disable-line no-unused-vars
       onChange, // eslint-disable-line no-unused-vars
       onFocus, // eslint-disable-line no-unused-vars
@@ -549,19 +539,13 @@ ChipInput.propTypes = {
   openOnFocus: PropTypes.bool,
   chipRenderer: PropTypes.func,
   newChipKeyCodes: PropTypes.arrayOf(PropTypes.number),
-  clearOnBlur: PropTypes.bool, // kept for compatibility
-  blurBehavior: PropTypes.oneOf([
-    'clear',
-    'add',
-    'addFirstSuggestion',
-    null
-  ])
+  clearOnBlur: PropTypes.bool
 }
 
 ChipInput.defaultProps = {
   filter: AutoComplete.caseInsensitiveFilter,
   newChipKeyCodes: [13],
-  blurBehavior: 'clear',
+  clearOnBlur: true,
   underlineShow: true
 }
 

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -156,7 +156,7 @@ class ChipInput extends React.Component {
       const index = parseInt(child.key, 10);
       const chosenRequest = dataSource[index];
       this.handleAddChip(chosenRequest)
-  
+
       this.autoComplete.setState({
         searchText: '',
       });
@@ -215,11 +215,24 @@ class ChipInput extends React.Component {
   }
 
   handleInputBlur = (event) => {
-    if (this.props.clearOnBlur) {
-      this.setState({ inputValue: '' })
+    if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
+      if (this.props.blurBehavior || this.props.clearOnBlur) {
+        if ((this.props.blurBehavior === 'add' || this.props.blurBehavior === 'addFirstSuggestion') && event.target.value) {
+          this.handleAddChip(event.target.value)
+        }
+        this.setState({ inputValue: '' })
+      }
+      this.setState({ isFocused: false })
+      if (this.props.onBlur) this.props.onBlur(event)
+    } else if (this.props.blurBehavior === 'addFirstSuggestion' && this.autoComplete.requestsList.length !== 0) {
+      const chipIndex = parseInt(this.autoComplete.requestsList[0].value.key, 10)
+      this.handleAddChip(this.props.dataSource[chipIndex])
+      this.setState({
+        isFocused: false,
+        inputValue: ''
+      })
+      if (this.props.onBlur) this.props.onBlur(event)
     }
-    this.setState({ isFocused: false })
-    if (this.props.onBlur) this.props.onBlur(event)
   }
 
   handleInputFocus = (event) => {
@@ -366,6 +379,7 @@ class ChipInput extends React.Component {
       id,
       inputStyle,
       clearOnBlur,
+      blurBehavior,
       onBlur, // eslint-disable-line no-unused-vars
       onChange, // eslint-disable-line no-unused-vars
       onFocus, // eslint-disable-line no-unused-vars
@@ -535,13 +549,19 @@ ChipInput.propTypes = {
   openOnFocus: PropTypes.bool,
   chipRenderer: PropTypes.func,
   newChipKeyCodes: PropTypes.arrayOf(PropTypes.number),
-  clearOnBlur: PropTypes.bool
+  clearOnBlur: PropTypes.bool, // kept for compatibility
+  blurBehavior: PropTypes.oneOf([
+    'clear',
+    'add',
+    'addFirstSuggestion',
+    null
+  ])
 }
 
 ChipInput.defaultProps = {
   filter: AutoComplete.caseInsensitiveFilter,
   newChipKeyCodes: [13],
-  clearOnBlur: true,
+  blurBehavior: 'clear',
   underlineShow: true
 }
 

--- a/stories/ControlledChipInput.js
+++ b/stories/ControlledChipInput.js
@@ -31,6 +31,11 @@ class ControlledChipInput extends React.Component {
       value={this.state.chips}
       onRequestAdd={(chip) => this.handleRequestAdd(chip)}
       onRequestDelete={(deletedChip) => this.handleRequestDelete(deletedChip)}
+      onBlur={(event) => {
+        if (this.props.addOnBlur && event.target.value) {
+          this.handleRequestAdd(event.target.value)
+        }
+      }}
       fullWidth
     />
   }

--- a/stories/ControlledChipInput.js
+++ b/stories/ControlledChipInput.js
@@ -41,4 +41,8 @@ class ControlledChipInput extends React.Component {
   }
 }
 
+ControlledChipInput.propTypes = {
+  addOnBlur: React.PropTypes.bool
+}
+
 export default ControlledChipInput

--- a/stories/index.js
+++ b/stories/index.js
@@ -200,3 +200,8 @@ storiesOf('ChipInput', module)
       onTouchTap={action('onTouchTap')}
     />
   ))
+  .add('add text input value on blur', () => themed(
+    <ControlledChipInput
+      addOnBlur
+    />
+  ))


### PR DESCRIPTION
Closes https://github.com/TeamWertarbyte/material-ui-chip-input/issues/63

I'll happily admit that this was written totally for my use case - especially my addition of an option to `addFirstSuggestion`, which adds the first item in the autocomplete when the input blurs - so please comment and we can do something more general and useful for everyone. I just thought it would be helpful to provide something! I didn't remove `clearOnBlur` so as not to make breaking changes.

If/when we've discussed this I'll also add something to the docs :)