### PR TITLE
handleInputBlur must pause before checking autocomplete status to support openOnFocus (issue #73)

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -218,12 +218,18 @@ class ChipInput extends React.Component {
     if (this.props.onBlur) {
       this.props.onBlur(event)
     }
-    if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
+
+    //A momentary delay is required to support openOnFocus. We must give time for the autocomplete
+    //menu to close before checking the current status. Otherwise, tabbing off the input while the
+    //menu is open results in the input keeping its focus styles.
+    setTimeout(() => {
+      if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
         if (this.props.clearOnBlur) {
           this.setState({ inputValue: '' })
         }
         this.setState({ isFocused: false })
       }
+    }, 0);
   }
 
   handleInputFocus = (event) => {


### PR DESCRIPTION
https://github.com/TeamWertarbyte/material-ui-chip-input/issues/73