### PR TITLE
Added default style to chip render function. Updated storybook example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import ChipInput from 'material-ui-chip-input'
 ## Properties
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| chipRenderer | `function` | | A function of the type `({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
+| chipRenderer | `function` | | A function of the type `({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete, defaultStyle  }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
 | clearOnBlur | `bool` | `true` | If true, clears the input value after the component loses focus. |
 | dataSource | `array` | | Data source for auto complete. |
 | dataSourceConfig | `object` | | Config for objects list dataSource, e.g. `{ text: 'text', value: 'value' }`. If not specified, the `dataSource` must be a flat array of strings. |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import ChipInput from 'material-ui-chip-input'
 ## Properties
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| chipRenderer | `function` | | A function of the type `({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete, defaultStyle  }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
+| chipRenderer | `function` | | A function of the type `({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete, defaultStyle }, key) => node` that returns a chip based on the given properties. This can be used to customize chip styles. |
 | clearOnBlur | `bool` | `true` | If true, clears the input value after the component loses focus. |
 | dataSource | `array` | | Data source for auto complete. |
 | dataSourceConfig | `object` | | Config for objects list dataSource, e.g. `{ text: 'text', value: 'value' }`. If not specified, the `dataSource` must be a flat array of strings. |

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -72,7 +72,8 @@ const getStyles = (props, context, state) => {
       transform: 'scale(0.75) translate(0, -36px)'
     },
     defaultChip: {
-      margin: '8px 8px 0 0', float: 'left'
+      margin: '8px 8px 0 0',
+      float: 'left'
     }
   };
 

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -371,7 +371,7 @@ class ChipInput extends React.Component {
    * Using a bound class method here to set `autoComplete` to avoid it being set
    * to null by an inline ref callback.
    *
-   * See [Isuue #71](https://github.com/TeamWertarbyte/material-ui-chip-input/issues/71)
+   * See [Issue #71](https://github.com/TeamWertarbyte/material-ui-chip-input/issues/71)
    *
    * @param {Object} autoComplete - The AutoComplete DOM element or null
    */

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -97,7 +97,7 @@ const getStyles = (props, context, state) => {
 const defaultChipRenderer = ({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete, defaultStyle }, key) => (
   <Chip
     key={key}
-    style={{...defaultStyle, pointerEvents: isDisabled ? 'none' : undefined }}
+    style={{ ...defaultStyle, pointerEvents: isDisabled ? 'none' : undefined }}
     backgroundColor={isFocused ? blue300 : null}
     onTouchTap={handleClick}
     onRequestDelete={handleRequestDelete}

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -70,6 +70,9 @@ const getStyles = (props, context, state) => {
     },
     floatingLabelFocusStyle: {
       transform: 'scale(0.75) translate(0, -36px)'
+    },
+    defaultChip: {
+      margin: '8px 8px 0 0', float: 'left'
     }
   };
 
@@ -90,10 +93,10 @@ const getStyles = (props, context, state) => {
   return styles;
 };
 
-const defaultChipRenderer = ({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete }, key) => (
+const defaultChipRenderer = ({ value, text, isFocused, isDisabled, handleClick, handleRequestDelete, defaultStyle }, key) => (
   <Chip
     key={key}
-    style={{ margin: '8px 8px 0 0', float: 'left', pointerEvents: isDisabled ? 'none' : undefined }}
+    style={{...defaultStyle, pointerEvents: isDisabled ? 'none' : undefined }}
     backgroundColor={isFocused ? blue300 : null}
     onTouchTap={handleClick}
     onRequestDelete={handleRequestDelete}
@@ -364,7 +367,7 @@ class ChipInput extends React.Component {
   /**
    * Sets a reference to the AutoComplete instance.
    *
-   * Using a bound class method here to set `autoComplete` to avoid it being set 
+   * Using a bound class method here to set `autoComplete` to avoid it being set
    * to null by an inline ref callback.
    *
    * See [Isuue #71](https://github.com/TeamWertarbyte/material-ui-chip-input/issues/71)
@@ -485,7 +488,8 @@ class ChipInput extends React.Component {
                 isDisabled: disabled,
                 isFocused: this.state.focusedChip === value,
                 handleClick: () => this.setState({ focusedChip: value }),
-                handleRequestDelete: () => this.handleDeleteChip(value, i)
+                handleRequestDelete: () => this.handleDeleteChip(value, i),
+                defaultStyle: styles.defaultChip
               }, i)
             })}
           </div>

--- a/stories/index.js
+++ b/stories/index.js
@@ -98,10 +98,10 @@ storiesOf('ChipInput', module)
     <ChipInput
       defaultValue={['foo', 'bar']}
       fullWidth
-      chipRenderer={({ value, isFocused, isDisabled, handleClick, handleRequestDelete }, key) => (
+      chipRenderer={({ value, isFocused, isDisabled, handleClick, handleRequestDelete, defaultStyle }, key) => (
         <Chip
           key={key}
-          style={{ margin: '8px 8px 0 0', float: 'left', pointerEvents: isDisabled ? 'none' : undefined }}
+          style={{ ...defaultStyle, pointerEvents: isDisabled ? 'none' : undefined }}
           backgroundColor={isFocused ? green800 : green300}
           onTouchTap={handleClick}
           onRequestDelete={handleRequestDelete}


### PR DESCRIPTION
I think it's useful to have the default base style for the chips in order to show the chips in a proper way so I added it to the custom chip render function call.
PR1