### PR TITLE
Added clearInput for clearing the input from outside of the component

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -362,7 +362,7 @@ class ChipInput extends React.Component {
     }
   }
 
-  clearInput (){
+  clearInput () {
     this.setState({ inputValue: '' })
   }
 

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -225,7 +225,7 @@ class ChipInput extends React.Component {
     setTimeout(() => {
       if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
         if (this.props.clearOnBlur) {
-          this.setState({ inputValue: '' })
+          this.clearInput()
         }
         this.setState({ isFocused: false })
       }
@@ -284,7 +284,8 @@ class ChipInput extends React.Component {
     if (this.props.newChipKeyCodes.indexOf(event.keyCode) < 0) {
       this.setState({ inputValue: event.target.value })
     } else {
-      this.setState({ inputValue: '' })}
+      this.clearInput()
+    }
   }
 
   handleAddChip (chip) {
@@ -359,6 +360,10 @@ class ChipInput extends React.Component {
         }
       }
     }
+  }
+
+  clearInput (){
+    this.setState({ inputValue: '' })
   }
 
   /**


### PR DESCRIPTION
I'm using the component in a controlled mode but the current methods are not enough. That's how I'm using the component:
`<ChipInput fullWidth value={this.state.query} onRequestAdd={(chip) => this.handleNewChip(chip)} chipRenderer={() => this.translateQueryToChips()} onUpdateInput={() =>this.handleSuggestions()} ref="search" />`
As you can see I'm using it controlled because I'm setting the value and handling the changes with two functions.
I'm using onUpdateInput for populate other autocomplete component outside from the chipInput (I'm not using the default one).
If the user clicks on this component suggestions, I add the selected item to the query so it is rendered, but the input text stays in the input. I know I can use clearOnBlur so as soon the user clicks outside from the component, the input will be emptied but on iPhone devices, the focus seems to work in a different way and as the component doesn't loose the focus even clicking outside, the text will stay.
For that reason, I need to clear the input (only the input component, not the chips) from outside in some cases
PR3