### PR TITLE
Added new prop getChipIndex to provide a way of hashing a non-hashabe value list in order to make the deletion via keyboard work

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ import ChipInput from 'material-ui-chip-input'
 | floatingLabelText | `node` | | The content of the floating label. |
 | fullWidth | `bool` | `false` | If true, the chip input will fill the available width. |
 | fullWidthInput | `bool` | `false` | If true, the input field will always be below the chips and fill the available space. By default, it will try to be beside the chips. |
+| getChipIndex | `function` | | If you're using a non-hashable element in the value prop, in order to make the deletion via keyboard work,  you can specify a function that returns an index given the values list and one element of the list. A function of the type `(list, listElement) => int`|
 | hintText | `node` | | The hint text to display. |
 | id | `string` | _a unique id_ | The id prop for the text field, should be set to some deteministic value if you use server-side rendering. |
 | newChipKeyCodes | `number[]` | `[13]` (enter key) | The key codes used to determine when to create a new chip. |

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -256,7 +256,14 @@ class ChipInput extends React.Component {
         if (this.state.focusedChip == null && event.keyCode === 8) {
           this.setState({ focusedChip: chips[chips.length - 1] })
         } else if (this.state.focusedChip) {
-          const index = chips.indexOf(this.state.focusedChip)
+
+          let index;
+          if (this.props.getChipIndex) {
+            index = this.props.getChipIndex(chips, this.state.focusedChip)
+          }else{
+            index = chips.indexOf(this.state.focusedChip)
+          }
+
           const value = this.props.dataSourceConfig ? this.state.focusedChip[this.props.dataSourceConfig.value] : this.state.focusedChip
           this.handleDeleteChip(value, index)
           if (event.keyCode === 8 && index > 0) {
@@ -367,7 +374,7 @@ class ChipInput extends React.Component {
     }
   }
 
-  clearInput () {
+  clearInput (){
     this.setState({ inputValue: '' })
   }
 
@@ -420,6 +427,7 @@ class ChipInput extends React.Component {
       onRequestDelete, // eslint-disable-line no-unused-vars
       chipRenderer = defaultChipRenderer,
       newChipKeyCodes, // eslint-disable-line no-unused-vars
+      getChipIndex, // eslint-disable-line no-unused-vars
       ...other,
     } = this.props;
 
@@ -570,7 +578,8 @@ ChipInput.propTypes = {
   openOnFocus: PropTypes.bool,
   chipRenderer: PropTypes.func,
   newChipKeyCodes: PropTypes.arrayOf(PropTypes.number),
-  clearOnBlur: PropTypes.bool
+  clearOnBlur: PropTypes.bool,
+  getChipIndex: PropTypes.func
 }
 
 ChipInput.defaultProps = {

--- a/stories/index.js
+++ b/stories/index.js
@@ -166,14 +166,15 @@ storiesOf('ChipInput', module)
   ))
   .add('objects as chips, controlled', () => themed(
     <ChipInput
-      dataSource={[{ label: 'Chip 1', id: 'one' }, { label: 'Chip 2', id: 'two' }]}
+      dataSource={[{ label: 'Chip 1', id: 'one' }, { label: 'Chip 2', id: 'two' }, { label: 'Chip 3', id: 'three' }]}
       dataSourceConfig={{ text: 'label', value: 'id' }}
-      value={[{ label: 'Chip 1', id: 'one' }]}
+      value={[{ label: 'Chip 1', id: 'one' }, { label: 'Chip 2', id: 'two' }]}
       onChange={action('onChange')}
       onUpdateInput={action('onUpdateInput')}
       onRequestDelete={action('onRequestDelete')}
       onRequestAdd={action('onRequestAdd')}
       onTouchTap={action('onTouchTap')}
+      getChipIndex={(values, valuesElement) => values.map(value => value.id).indexOf(valuesElement.id)}
     />
   ))
   .add('controlled input with auto complete', () => themed(


### PR DESCRIPTION
If you use an array of non-hashable elements for the value prop, the deletion via keyboard won't work because `chips.indexOf(this.state.focusedChip)` will return -1 
For solving that, I added new prop that should have a function that given two inputs (the values list and one element of the list) will return the id of the element in the list.

I updated the docs and also one example in the storybook