### PR TITLE
Update peer and dev dependencies for material-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
-    "material-ui": "^0.16.2",
+    "material-ui": "^0.17.0",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-tap-event-plugin": "^2.0.0"
   },
   "peerDependencies": {
-    "material-ui": ">= 0.15.0 <= 0.16.x",
+    "material-ui": ">= 0.15.0 <= 0.17.x",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-tap-event-plugin": "^1.0.0 || ^2.0.0"


### PR DESCRIPTION
This commit updates the dependencies to include latest stable release of material-ui (0.17.0).

Manual run through the storybook and did not uncover any obvious regressions.