### PR TITLE
Use `prop-types` lib instead of deprecated React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-tap-event-plugin": "^1.0.0 || ^2.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.7"
   }
 }

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -2,7 +2,8 @@
  * Notice: Some code was adapted from Material-UI's text field.
  *         Copyright (c) 2014 Call-Em-All (https://github.com/callemall/material-ui)
  */
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import TextFieldUnderline from 'material-ui/TextField/TextFieldUnderline'
 import TextFieldHint from 'material-ui/TextField/TextFieldHint'
 import TextFieldLabel from 'material-ui/TextField/TextFieldLabel'


### PR DESCRIPTION
Use the prop-types library to avoid React 15.5 deprecation warning.

For testing, ran `npm run build` and `npm run storybook` to confirm visual and functional parity.

Note that `prop-types` was added to `dependencies`, as per the recommendations in [this PR](https://github.com/callemall/material-ui/pull/6577).