### PR TITLE
Avoid form submit for events meant to add chips

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -147,6 +147,7 @@ class ChipInput extends React.Component {
     const handleKeyDown = this.autoComplete.handleKeyDown
     this.autoComplete.handleKeyDown = (event) => {
       if (this.props.newChipKeyCodes.indexOf(event.keyCode) >= 0) {
+        event.preventDefault()
         this.handleAddChip(event.target.value)
         this.autoComplete.setState({ searchText: '' })
         this.autoComplete.forceUpdate()

--- a/stories/index.js
+++ b/stories/index.js
@@ -205,10 +205,11 @@ storiesOf('ChipInput', module)
       addOnBlur
     />
   ))
-  .add('single form field', () => themed(
+  .add('in a form', () => themed(
     <form>
       <ChipInput
         onChange={action('onChange')}
+        floatingLabelText="This is a single chip input inside a <code>form</code>. Note that pressing Enter in the chip input does not submit the form."
         fullWidth
       />
     </form>

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,9 +15,7 @@ function themed(children) {
   return (
     <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
       <div style={{ fontFamily: 'Roboto, sans-serif' }}>
-        <form>
-          {children}
-        </form>
+        {children}
       </div>
     </MuiThemeProvider>
   )
@@ -206,4 +204,12 @@ storiesOf('ChipInput', module)
     <ControlledChipInput
       addOnBlur
     />
+  ))
+  .add('single form field', () => themed(
+    <form>
+      <ChipInput
+        onChange={action('onChange')}
+        fullWidth
+      />
+    </form>
   ))

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,7 +15,9 @@ function themed(children) {
   return (
     <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
       <div style={{ fontFamily: 'Roboto, sans-serif' }}>
-        {children}
+        <form>
+          {children}
+        </form>
       </div>
     </MuiThemeProvider>
   )


### PR DESCRIPTION
This is mainly necessary for forms that contain a single ChipInput and nothing else as the default behaviour for *Enter* is to submit the form as per https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2

Adding the `<form>` wrapper in the story makes this more apparent (tested in recentish Chrome, Safari, Firefox on OSX).

I considered limiting it to the *Enter* key code, but I think it makes sense generally that if some key event is being handled by the component the default behaviour should be stopped. I'd be interested in your thoughts on the matter.