### PR TITLE
Let new chip key events bubble up if a chip isn't being added

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -145,7 +145,8 @@ class ChipInput extends React.Component {
   componentDidMount () {
     const handleKeyDown = this.autoComplete.handleKeyDown
     this.autoComplete.handleKeyDown = (event) => {
-      if (this.props.newChipKeyCodes.indexOf(event.keyCode) >= 0) {
+      const {newChipKeyCodes} = this.props
+      if (newChipKeyCodes.indexOf(event.keyCode) >= 0 && event.target.value) {
         event.preventDefault()
         this.handleAddChip(event.target.value)
         this.autoComplete.setState({ searchText: '' })

--- a/stories/index.js
+++ b/stories/index.js
@@ -206,10 +206,10 @@ storiesOf('ChipInput', module)
     />
   ))
   .add('in a form', () => themed(
-    <form>
+    <form onSubmit={e => {e.preventDefault(); action('onSubmit')()}}>
       <ChipInput
         onChange={action('onChange')}
-        floatingLabelText='This is a single chip input inside a <code>form</code>. Note that pressing Enter in the chip input does not submit the form.'
+        floatingLabelText='This is a single chip input inside a form. Note that pressing Enter does not submit the form if a chip is being added.'
         fullWidth
       />
     </form>
@@ -219,4 +219,15 @@ storiesOf('ChipInput', module)
        defaultValue={['foo', 'bar', 'foo', 'bar']}
        allowDuplicates
     />
-))
+  ))
+  .add('tabbing between fields', () => themed(
+    <form>
+      <ChipInput
+        floatingLabelText='"Tab" key selects the next field when there is no active chip.'
+        newChipKeyCodes={[9, 13]}
+        fullWidth
+      />
+      <br />
+      <input type="text" />
+    </form>
+  ))


### PR DESCRIPTION
I just noticed that the default tab behaviour of switching between form fields is broken due to my previous PR about the Enter key's default behaviour.

This fixes tabbing (or realistically any such functionality) by only preventing the event's default behaviour if there isn't a new chip value being added. I've also updated the related story to better explain when the form should/shouldn't submit.