### PR TITLE
override overrideRootStyles

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -490,7 +490,7 @@ class ChipInput extends React.Component {
     return (
       <div
         className={className}
-        style={prepareStyles(Object.assign(styles.root, style, overrideRootStyles))}
+        style={prepareStyles(Object.assign(styles.root, overrideRootStyles, style))}
         onTouchTap={() => this.focus()}
       >
         <div>


### PR DESCRIPTION
Instead of overwriting `props.style` with `overrideRootStyles`, do the opposite. In this way we can override properties in `overrideRootStyles`.