### PR TITLE
IME bug fix

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -253,6 +253,7 @@ class ChipInput extends React.Component {
   }
 
   handleKeyDown = (event) => {
+    this.setState({keyPressed: false})
     if (this.props.newChipKeyCodes.indexOf(event.keyCode) >= 0) {
       this.handleAddChip(event.target.value)
     } else if (event.keyCode === 8 || event.keyCode === 46) {
@@ -291,11 +292,15 @@ class ChipInput extends React.Component {
   }
 
   handleKeyUp = (event) => {
-    if (this.props.newChipKeyCodes.indexOf(event.keyCode) < 0) {
+    if (this.props.newChipKeyCodes.indexOf(event.keyCode) < 0 && this.state.keyPressed) {
       this.setState({ inputValue: event.target.value })
     } else {
       this.clearInput()
     }
+  }
+
+  handleKeyPress = (event) => {
+    this.setState({keyPressed: true})
   }
 
   handleAddChip (chip) {
@@ -529,6 +534,7 @@ class ChipInput extends React.Component {
           searchText={this.state.inputValue}
           underlineShow={false}
           onKeyUp={this.handleKeyUp}
+          onKeyPress={this.handleKeyPress}
           ref={this.setAutoComplete}
         />
         {underlineShow


### PR DESCRIPTION
Hi, I wanted to use this component in my project, but I couldn't use with Japanese IME.
Problem was when I hit Enter while I type Japanese, it fires `handleKeyup` and clears input, but input is not there yet and chip is not created.

![wefkknwjyt](https://user-images.githubusercontent.com/1161197/28010750-e30535b2-659a-11e7-9176-98fd5396119f.gif)

While editing input with IME, `handleKeyPress` won't be fired, so I added state to check if the input with Keypress fired or not.

![lnizjexdwf](https://user-images.githubusercontent.com/1161197/28010902-7175acb4-659b-11e7-9ffe-b4adbff58a3a.gif)

I guess this fix works on other IME as well but not so sure.

It seems like working fine, but if this seems to trigger other problem, let me know!