### PR TITLE
Add !this.props.disabled condition to focus()

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -197,7 +197,7 @@ class ChipInput extends React.Component {
   focus () {
     if (this.autoComplete) {
       this.getInputNode().focus()
-      if (this.props.openOnFocus) {
+      if (this.props.openOnFocus && !this.props.disabled) {
         this.autoComplete.setState({
           open: true,
           anchorEl: this.getInputNode()


### PR DESCRIPTION
If both `openOnFocus` and `disabled` props are `true`, the AutoComplete menu still opens on focus. I think `disabled` should override the `openOnFocus` behavior.