### PR TITLE
Refactor `themed` function to decorator

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -11,61 +11,58 @@ import ChipInput from '../src/ChipInput'
 import ControlledChipInput from './ControlledChipInput'
 import ClipboardExample from './ClipboardExample'
 
-function themed (children) {
-  return (
+storiesOf('ChipInput', module)
+  .addDecorator((story) =>
     <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
       <div style={{ fontFamily: 'Roboto, sans-serif' }}>
-        {children}
+        {story()}
       </div>
     </MuiThemeProvider>
   )
-}
-
-storiesOf('ChipInput', module)
-  .add('with some chips', () => themed(
+  .add('with some chips', () =>
     <ChipInput
       defaultValue={['foo', 'bar']}
       fullWidth
       onChange={action('onChange')}
     />
-  ))
-  .add('with many chips', () => themed(
+  )
+  .add('with many chips', () =>
     <ChipInput
       defaultValue={[...Array(25).keys()].map((c) => `Chip ${c}`)}
       onChange={action('onChange')}
       fullWidth
     />
-  ))
-  .add('with custom chip container styles', () => themed(
+  )
+  .add('with custom chip container styles', () =>
     <ChipInput
       fullWidth
       onChange={action('onChange')}
       chipContainerStyle={{ overflow: 'auto', maxHeight: '56px' }}
       defaultValue={[...Array(100).keys()].map((c) => `Chip ${c}`)}
     />
-  ))
-  .add('with hintText', () => themed(
+  )
+  .add('with hintText', () =>
     <ChipInput
       hintText='Hint text'
       fullWidth
     />
-  ))
-  .add('with auto complete', () => themed(
+  )
+  .add('with auto complete', () =>
     <ChipInput
       fullWidth
       dataSource={['alpha', 'beta']}
       hintText='Try typing a...'
     />
-  ))
-  .add('with auto complete, open on focus', () => themed(
+  )
+  .add('with auto complete, open on focus', () =>
     <ChipInput
       fullWidth
       openOnFocus
       dataSource={['alpha', 'beta']}
       hintText='Try typing a...'
     />
-  ))
-  .add('with auto complete, custom filter, open on focus', () => themed(
+  )
+  .add('with auto complete, custom filter, open on focus', () =>
     <ChipInput
       fullWidth
       openOnFocus
@@ -73,36 +70,36 @@ storiesOf('ChipInput', module)
       dataSource={['alpha', 'beta']}
       hintText='Try typing apha...'
     />
-  ))
-  .add('with floating label', () => themed(
+  )
+  .add('with floating label', () =>
     <ChipInput
       floatingLabelText='Floating label'
       fullWidth
     />
-  ))
-  .add('with floating label and hint text', () => themed(
+  )
+  .add('with floating label and hint text', () =>
     <ChipInput
       floatingLabelText='Floating label'
       hintText='Hint text'
       fullWidth
     />
-  ))
-  .add('disabled', () => themed(
+  )
+  .add('disabled', () =>
     <ChipInput
       defaultValue={['foo', 'bar']}
       floatingLabelText='Disabled input'
       disabled
       fullWidth
     />
-  ))
-  .add('with custom width', () => themed(
+  )
+  .add('with custom width', () =>
     <ChipInput
       defaultValue={['foo', 'bar']}
       floatingLabelText='A chip input with a width of 321px'
       style={{ width: 321 }}
     />
-  ))
-  .add('with custom chips', () => themed(
+  )
+  .add('with custom chips', () =>
     <ChipInput
       defaultValue={['foo', 'bar']}
       fullWidth
@@ -119,34 +116,34 @@ storiesOf('ChipInput', module)
         </Chip>
       )}
     />
-  ))
-  .add('with errorText', () => themed(
+  )
+  .add('with errorText', () =>
     <ChipInput
       errorText='This is an error.'
     />
-  ))
-  .add('with errorStyle', () => themed(
+  )
+  .add('with errorStyle', () =>
     <ChipInput
       errorText='This is an error.'
       errorStyle={{ color: 'purple' }}
     />
-  ))
-  .add('without underline', () => themed(
+  )
+  .add('without underline', () =>
     <ChipInput
       defaultValue={['foo', 'bar']}
       fullWidth
       underlineShow={false}
     />
-  ))
-  .add('create tags with comma, space and enter', () => themed(
+  )
+  .add('create tags with comma, space and enter', () =>
     <ChipInput
       newChipKeyCodes={[13, 188, 32]}
     />
-  ))
-  .add('controlled input', () => themed(
+  )
+  .add('controlled input', () =>
     <ControlledChipInput />
-  ))
-  .add('uncontrolled verbose log', () => themed(
+  )
+  .add('uncontrolled verbose log', () =>
     <ChipInput
       defaultValue={['foo', 'bar']}
       onChange={action('onChange')}
@@ -155,8 +152,8 @@ storiesOf('ChipInput', module)
       onRequestAdd={action('onRequestAdd')}
       onClick={action('onClick')}
     />
-  ))
-  .add('controlled verbose log', () => themed(
+  )
+  .add('controlled verbose log', () =>
     <ChipInput
       value={['foo', 'bar']}
       onChange={action('onChange')}
@@ -165,8 +162,8 @@ storiesOf('ChipInput', module)
       onRequestAdd={action('onRequestAdd')}
       onClick={action('onClick')}
     />
-  ))
-  .add('objects as chips, uncontrolled', () => themed(
+  )
+  .add('objects as chips, uncontrolled', () =>
     <ChipInput
       dataSource={[{ label: 'Chip 1', id: 'one' }, { label: 'Chip 2', id: 'two' }]}
       dataSourceConfig={{ text: 'label', value: 'id' }}
@@ -177,8 +174,8 @@ storiesOf('ChipInput', module)
       onRequestAdd={action('onRequestAdd')}
       onClick={action('onClick')}
     />
-  ))
-  .add('objects as chips, controlled', () => themed(
+  )
+  .add('objects as chips, controlled', () =>
     <ChipInput
       dataSource={[{ label: 'Chip 1', id: 'one' }, { label: 'Chip 2', id: 'two' }]}
       dataSourceConfig={{ text: 'label', value: 'id' }}
@@ -189,22 +186,22 @@ storiesOf('ChipInput', module)
       onRequestAdd={action('onRequestAdd')}
       onClick={action('onClick')}
     />
-  ))
-  .add('controlled input with auto complete', () => themed(
+  )
+  .add('controlled input with auto complete', () =>
     <ControlledChipInput
       openOnFocus
       dataSource={['foo', 'bar']}
       inputProps={{ fullWidth: true }}
     />
-  ))
-  .add('with fullWidthInput', () => themed(
+  )
+  .add('with fullWidthInput', () =>
     <ChipInput
       floatingLabelText='The input is always full-width here'
       fullWidth
       fullWidthInput
     />
-  ))
-  .add('with clipboard manipulation', () => themed(
+  )
+  .add('with clipboard manipulation', () =>
     <ClipboardExample
       onPaste={action('onPaste')}
       onChange={action('onChange')}
@@ -213,13 +210,13 @@ storiesOf('ChipInput', module)
       onRequestAdd={action('onRequestAdd')}
       onClick={action('onClick')}
     />
-  ))
-  .add('add text input value on blur', () => themed(
+  )
+  .add('add text input value on blur', () =>
     <ControlledChipInput
       addOnBlur
     />
-  ))
-  .add('in a form', () => themed(
+  )
+  .add('in a form', () =>
     <form onSubmit={e => { e.preventDefault(); action('onSubmit')() }}>
       <ChipInput
         onChange={action('onChange')}
@@ -227,14 +224,14 @@ storiesOf('ChipInput', module)
         fullWidth
       />
     </form>
-  ))
-   .add('with duplicates allowed', () => themed(
-     <ChipInput
-       defaultValue={['foo', 'bar', 'foo', 'bar']}
-       allowDuplicates
+  )
+  .add('with duplicates allowed', () =>
+    <ChipInput
+      defaultValue={['foo', 'bar', 'foo', 'bar']}
+      allowDuplicates
     />
-  ))
-  .add('tabbing between fields', () => themed(
+  )
+  .add('tabbing between fields', () =>
     <form>
       <ChipInput
         floatingLabelText='"Tab" key selects the next field when there is no active chip.'
@@ -244,4 +241,4 @@ storiesOf('ChipInput', module)
       <br />
       <input type='text' />
     </form>
-  ))
+  )


### PR DESCRIPTION
Thanks for sharing this component. I continue to be impressed by this project, as it is really well made, well maintained, and documented. I have found it extremely helpful in a number of projects, and for that I would like to thank everyone who has contributed to it. 

I refactored `stories/index.js`, as storybook's `addDecorator` function allows one to theme all of the stories using `MuiThemeProvider` without repeated use of the `themed` function. This allows for less duplication/boilerplate/cruft (no more `() => themed(...)`) in the stories, since the decorator applies the theme to each story. This makes individual stories somewhat simpler while not changing any functionality.

I also fixed the indentation of one story which failed `standard` compliance due to an extra leading space.

Thanks again!