### PR TITLE
Fix npm@5 warnings on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "babel src -d lib",
     "test": "standard",
     "lint": "standard",
-    "prepublish": "babel src -d lib",
+    "prepare": "npm run build",
     "storybook": "start-storybook -p 6006",
     "deploy-storybook": "build-storybook -o storybook && gh-pages -d storybook && rm -r storybook"
   },


### PR DESCRIPTION
Fixes warnings on install:

```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```