### PR TITLE
Adjust auto complete renaming from touch to click event

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -158,7 +158,7 @@ class ChipInput extends React.Component {
       }
     }
 
-    this.autoComplete.handleItemTouchTap = (event, child) => {
+    this.autoComplete.handleItemClick = (event, child) => {
       const dataSource = this.autoComplete.props.dataSource
 
       const index = parseInt(child.key, 10)


### PR DESCRIPTION
material-ui 0.20 changed the autocomplete's method name `handleItemTouchTap` to `handleItemClick`.