### PR TITLE
Upgrading material ui to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "standard": "^10.0.2"
   },
   "peerDependencies": {
-    "material-ui": ">= 0.20.0 < 1.0.0",
+    "material-ui": ">= 0.19.1 < 1.0.0",
     "react": "^15.3.2 || ^16.0.0",
     "react-dom": "^15.3.2 || ^16.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
     "gh-pages": "^1.0.0",
-    "material-ui": "^0.19.1",
+    "material-ui": "^0.20.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "standard": "^10.0.2"
   },
   "peerDependencies": {
-    "material-ui": ">= 0.19.0 < 1.0.0",
+    "material-ui": ">= 0.20.0 < 1.0.0",
     "react": "^15.3.2 || ^16.0.0",
     "react-dom": "^15.3.2 || ^16.0.0"
   },

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -158,7 +158,7 @@ class ChipInput extends React.Component {
       }
     }
 
-    this.autoComplete.handleItemClick = (event, child) => {
+    const onAutocompleteItemClick =  (event, child) => {
       const dataSource = this.autoComplete.props.dataSource
 
       const index = parseInt(child.key, 10)
@@ -168,6 +168,12 @@ class ChipInput extends React.Component {
       this.autoComplete.close()
 
       setTimeout(() => this.focus(), 1)
+    }
+
+    if (this.autoComplete.handleItemClick) {
+      this.autoComplete.handleItemClick = onAutocompleteItemClick;
+    } else {
+      this.autoComplete.handleItemTouchTap = onAutocompleteItemClick
     }
 
     // force update autocomplete to ensure that it uses the new handlers

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -158,7 +158,7 @@ class ChipInput extends React.Component {
       }
     }
 
-    this.autoComplete.handleItemTouchTap = (event, child) => {
+    this.autoComplete.handleItemClick = (event, child) => {
       const dataSource = this.autoComplete.props.dataSource
 
       const index = parseInt(child.key, 10)

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -170,6 +170,7 @@ class ChipInput extends React.Component {
       setTimeout(() => this.focus(), 1)
     }
 
+    // Ensuring that ChipInput works with with Material-UI 0.19.1 and 0.20.0
     if (this.autoComplete.handleItemClick) {
       this.autoComplete.handleItemClick = onAutocompleteItemClick;
     } else {


### PR DESCRIPTION
Material-UI was upgraded to 0.2.0 removing all internal TouchTap references.

changed `this.autoComplete.handleItemTouchTap` => `this.autoComplete.handleItemClick`