### PR TITLE
Make autocomplete MenuItems customizable

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -618,8 +618,7 @@ ChipInput.propTypes = {
   chipRenderer: PropTypes.func,
   newChipKeyCodes: PropTypes.arrayOf(PropTypes.number),
   clearOnBlur: PropTypes.bool,
-  allowDuplicates: PropTypes.bool,
-  autoCompleteItemRenderer: PropTypes.func
+  allowDuplicates: PropTypes.bool
 }
 
 ChipInput.defaultProps = {

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -341,9 +341,7 @@ class ChipInput extends React.Component {
           [this.props.dataSourceConfig.text]: chip,
           [this.props.dataSourceConfig.value]: chip
         }
-      }
-
-      if (typeof chip === 'object') {
+      } else if (typeof chip === 'object') {
         if (chip[this.props.dataSourceConfig.text].length === 0 || chip[this.props.dataSourceConfig.value].length === 0) {
           return;
         }
@@ -620,7 +618,8 @@ ChipInput.propTypes = {
   chipRenderer: PropTypes.func,
   newChipKeyCodes: PropTypes.arrayOf(PropTypes.number),
   clearOnBlur: PropTypes.bool,
-  allowDuplicates: PropTypes.bool
+  allowDuplicates: PropTypes.bool,
+  autoCompleteItemRenderer: PropTypes.func
 }
 
 ChipInput.defaultProps = {

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -343,7 +343,7 @@ class ChipInput extends React.Component {
         }
       } else if (typeof chip === 'object') {
         if (chip[this.props.dataSourceConfig.text].length === 0 || chip[this.props.dataSourceConfig.value].length === 0) {
-          return;
+          return
         }
         chip = {
           [this.props.dataSourceConfig.text]: chip[this.props.dataSourceConfig.text],

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -343,6 +343,13 @@ class ChipInput extends React.Component {
         }
       }
 
+      if (typeof chip === 'object') {
+        chip = {
+          [this.props.dataSourceConfig.text]: chip[this.props.dataSourceConfig.text],
+          [this.props.dataSourceConfig.value]: chip[this.props.dataSourceConfig.value]
+        }
+      }
+
       if (this.props.allowDuplicates || !chips.some((c) => c[this.props.dataSourceConfig.value] === chip[this.props.dataSourceConfig.value])) {
         if (this.props.value) {
           if (this.props.onRequestAdd) {

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -344,6 +344,9 @@ class ChipInput extends React.Component {
       }
 
       if (typeof chip === 'object') {
+        if (chip[this.props.dataSourceConfig.text].length === 0 || chip[this.props.dataSourceConfig.value].length === 0) {
+          return;
+        }
         chip = {
           [this.props.dataSourceConfig.text]: chip[this.props.dataSourceConfig.text],
           [this.props.dataSourceConfig.value]: chip[this.props.dataSourceConfig.value]

--- a/stories/index.js
+++ b/stories/index.js
@@ -7,11 +7,11 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import Avatar from 'material-ui/Avatar'
 import Chip from 'material-ui/Chip'
 import AutoComplete from 'material-ui/AutoComplete'
+import MenuItem from 'material-ui/MenuItem/MenuItem'
 import { green800, green300 } from 'material-ui/styles/colors'
 import ChipInput from '../src/ChipInput'
 import ControlledChipInput from './ControlledChipInput'
 import ClipboardExample from './ClipboardExample'
-import MenuItem from 'material-ui/MenuItem/MenuItem';
 
 storiesOf('ChipInput', module)
   .addDecorator((story) =>
@@ -259,7 +259,7 @@ storiesOf('ChipInput', module)
             primaryText='Foo'
             secondaryText='&#9786;'
           />
-        ),
+        )
       },
       {
         text: 'Bar',
@@ -268,13 +268,13 @@ storiesOf('ChipInput', module)
             primaryText='Bar'
             secondaryText='&#9786;'
           />
-        ),
-      },
-    ];
+        )
+      }
+    ]
     const dataSourceConfig = {
       text: 'text',
       value: 'value'
-    };
+    }
 
     return (
       <ChipInput
@@ -282,4 +282,4 @@ storiesOf('ChipInput', module)
         dataSourceConfig={dataSourceConfig}
       />
     )
-  });
+  })

--- a/stories/index.js
+++ b/stories/index.js
@@ -11,6 +11,7 @@ import { green800, green300 } from 'material-ui/styles/colors'
 import ChipInput from '../src/ChipInput'
 import ControlledChipInput from './ControlledChipInput'
 import ClipboardExample from './ClipboardExample'
+import MenuItem from 'material-ui/MenuItem/MenuItem';
 
 storiesOf('ChipInput', module)
   .addDecorator((story) =>
@@ -249,3 +250,36 @@ storiesOf('ChipInput', module)
       <input type='text' />
     </form>
   )
+  .add('with custom menu items', () => {
+    const dataSource = [
+      {
+        text: 'Foo',
+        value: (
+          <MenuItem
+            primaryText='Foo'
+            secondaryText='&#9786;'
+          />
+        ),
+      },
+      {
+        text: 'Bar',
+        value: (
+          <MenuItem
+            primaryText='Bar'
+            secondaryText='&#9786;'
+          />
+        ),
+      },
+    ];
+    const dataSourceConfig = {
+      text: 'text',
+      value: 'value'
+    };
+
+    return (
+      <ChipInput
+        dataSource={dataSource}
+        dataSourceConfig={dataSourceConfig}
+      />
+    )
+  });


### PR DESCRIPTION
Fixes [#172](https://github.com/TeamWertarbyte/material-ui-chip-input/issues/172)
* Added ability to process object chips