### PR TITLE
Scroll through autocomplete results on overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,12 +1024,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1056,6 +1050,12 @@
               }
             }
           }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "style-loader": {
           "version": "0.18.2",
@@ -8417,15 +8417,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8457,6 +8448,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.2",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -438,6 +438,7 @@ class ChipInput extends React.Component {
 
   render () {
     const {
+      autocompleteHeight,
       children,
       className,
       dataSourceConfig,
@@ -575,6 +576,7 @@ class ChipInput extends React.Component {
           style={inputStyleMerged}
           dataSource={autoCompleteData}
           dataSourceConfig={dataSourceConfig}
+          listStyle={{ maxHeight: autocompleteHeight || '300px', overflow: 'scroll' }}
           searchText={this.state.inputValue}
           underlineShow={false}
           ref={this.setAutoComplete}

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -438,7 +438,7 @@ class ChipInput extends React.Component {
 
   render () {
     const {
-      autocompleteHeight,
+      autoCompleteListStyle,
       children,
       className,
       dataSourceConfig,
@@ -576,7 +576,7 @@ class ChipInput extends React.Component {
           style={inputStyleMerged}
           dataSource={autoCompleteData}
           dataSourceConfig={dataSourceConfig}
-          listStyle={{ maxHeight: autocompleteHeight || '300px', overflow: 'scroll' }}
+          listStyle={autoCompleteListStyle}
           searchText={this.state.inputValue}
           underlineShow={false}
           ref={this.setAutoComplete}

--- a/stories/index.js
+++ b/stories/index.js
@@ -73,8 +73,9 @@ storiesOf('ChipInput', module)
       hintText='Try typing apha...'
     />
   )
-  .add('with auto complete with lots of options', () =>
+  .add('with scrollable auto complete', () =>
     <ChipInput
+      autoCompleteListStyle={{ maxHeight: '300px', overflow: 'scroll' }}
       fullWidth
       dataSource={['alpha', 'beta', 'gamma', 'delta', 'zeta', 'eta', 'theta', 'iota']}
       hintText='Try typing a...'

--- a/stories/index.js
+++ b/stories/index.js
@@ -73,6 +73,13 @@ storiesOf('ChipInput', module)
       hintText='Try typing apha...'
     />
   )
+  .add('with auto complete with lots of options', () =>
+    <ChipInput
+      fullWidth
+      dataSource={['alpha', 'beta', 'gamma', 'delta', 'zeta', 'eta', 'theta', 'iota']}
+      hintText='Try typing a...'
+    />
+  )
   .add('with floating label', () =>
     <ChipInput
       floatingLabelText='Floating label'


### PR DESCRIPTION
In the case of lots of autocomplete options, it's important that all results are visible on the screen. This PR adds a default max height for the autocomplete component, which can be overridden with a new `autocompleteHeight` property. If the autocomplete results can't fit within this height, the results will become scrollable. Check out storybook for the `with autocomplete with lots of options` example to see it in action:
![scrollingautocomplete](https://user-images.githubusercontent.com/6805216/39439637-25e8310a-4c5d-11e8-9ea5-2c577d9a29c5.gif)
