### PR TITLE
changed inputProp name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import ChipInput from 'material-ui-chip-input'
 |helperText|`node`||Helper text that is displayed below the input.|
 |InputLabelProps|`object`||Props to pass through to the `InputLabel`.|
 |inputRef|`func`||Use this property to pass a ref callback to the native input component.|
+|inputProps|`shape`||Attributes applied to the input element.|
 |label|`node`|||
 |newChipKeyCodes|`arrayOf`|`[13]`|The key codes used to determine when to create a new chip.|
 |onAdd|`func`||Callback function that is called when a new chip was added (in controlled mode).|

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -406,7 +406,7 @@ class ChipInput extends React.Component {
       fullWidthInput,
       helperText,
       id,
-      InputProps,
+      inputProps,
       inputRef,
       InputLabelProps,
       label,
@@ -501,7 +501,7 @@ class ChipInput extends React.Component {
             disableUnderline
             fullWidth={fullWidthInput}
             placeholder={!hasInput && (shrinkFloatingLabel || label == null) ? placeholder : null}
-            {...InputProps}
+            {...inputProps}
           />
         </div>
         {helperText && (
@@ -548,7 +548,7 @@ ChipInput.propTypes = {
   /** Props to pass through to the `InputLabel`. */
   InputLabelProps: PropTypes.object,
   /** Props to pass through to the `Input`. */
-  InputProps: PropTypes.object,
+  inputProps: PropTypes.object,
   /** Use this property to pass a ref callback to the native input component. */
   inputRef: PropTypes.func,
   /* The content of the floating label. */


### PR DESCRIPTION
I would like to change the property name like the convention in material-ui.
from **InputProps** to **inputProps**

- [x] changed prop named
- [x] updated README