### PR TITLE
Add classes and margin props to type declaration

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FormControlProps } from '@material-ui/core/FormControl';
 import { FormHelperTextProps } from '@material-ui/core/FormHelperText';
 import { InputProps } from '@material-ui/core/Input';
 import { InputLabelProps } from '@material-ui/core/InputLabel';
@@ -19,7 +20,11 @@ export type ChipRenderer = (
   key: any
 ) => React.ReactNode;
 
-export interface Props {
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+// omitting onChange from FormControlProps as we use a custom onChange
+export interface Props extends Omit<FormControlProps, 'onChange'> {
   allowDuplicates?: boolean;
   blurBehavior?: 'clear' | 'add' | 'ignore';
   chipRenderer?: ChipRenderer;
@@ -40,7 +45,6 @@ export interface Props {
   InputProps?: InputProps;
   inputRef?: (ref: React.Ref<HTMLInputElement>) => any;
   label?: React.ReactNode;
-  margin?: 'none' | 'dense' | 'normal';
   newChipKeyCodes?: number[];
   onAdd?: (chip: any) => any;
   onBeforeAdd?: (chip: any) => boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,6 +23,7 @@ export interface Props {
   allowDuplicates?: boolean;
   blurBehavior?: 'clear' | 'add' | 'ignore';
   chipRenderer?: ChipRenderer;
+  classes: Record<string, string>;
   clearInputValueOnChange?: boolean;
   dataSource?: any[];
   dataSourceConfig?: {
@@ -39,6 +40,7 @@ export interface Props {
   InputProps?: InputProps;
   inputRef?: (ref: React.Ref<HTMLInputElement>) => any;
   label?: React.ReactNode;
+  margin?: 'none' | 'dense' | 'normal';
   newChipKeyCodes?: number[];
   onAdd?: (chip: any) => any;
   onBeforeAdd?: (chip: any) => boolean;


### PR DESCRIPTION
Partially addresses #239.

Initially tried to extend `FormControlProps` so all the missing props would be added, but this fails due to type mismatch between `onChange` in `Props` (which takes chips as its argument) vs in `FormControlProps` (which takes a change event).