### PR TITLE
Fix double elements in on change callback

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -337,10 +337,7 @@ class ChipInput extends React.Component {
         if (this.props.value && this.props.onAdd) {
           this.props.onAdd(chip)
         } else {
-          this.setState({ chips: [ ...this.state.chips, chip ] })
-          if (this.props.onChange) {
-            this.props.onChange([ ...this.state.chips, chip ])
-          }
+          this.updateChips([ ...this.state.chips, chip ])
         }
       }
     } else if (chip.trim().length > 0) {
@@ -348,10 +345,7 @@ class ChipInput extends React.Component {
         if (this.props.value && this.props.onAdd) {
           this.props.onAdd(chip)
         } else {
-          this.setState({ chips: [ ...this.state.chips, chip ] })
-          if (this.props.onChange) {
-            this.props.onChange([ ...this.state.chips, chip ])
-          }
+          this.updateChips([ ...this.state.chips, chip ])
         }
       }
     } else {
@@ -375,11 +369,15 @@ class ChipInput extends React.Component {
         } else if (this.state.focusedChip > i) {
           focusedChip = this.state.focusedChip - 1
         }
-        this.setState({ chips, focusedChip })
-        if (this.props.onChange) {
-          this.props.onChange(chips)
-        }
+        this.updateChips(chips, { focusedChip })
       }
+    }
+  }
+
+  updateChips (chips, additionalUpdates = {}) {
+    this.setState({ chips, ...additionalUpdates })
+    if (this.props.onChange) {
+      this.props.onChange(chips)
     }
   }
 

--- a/src/ChipInput.spec.js
+++ b/src/ChipInput.spec.js
@@ -386,9 +386,10 @@ describe('blurBehavior modes', () => {
     expect(tree.find('input').getDOMNode().value).toBe('')
     expect(setTimeout).toHaveBeenCalledTimes(1)
 
-    setTimeout(_ => {
-      expect(tree.find('Chip').map((chip) => chip.text())).toEqual(['a', 'b', 'blur'])
-    })
+    expect(handleChange.mock.calls[0][0]).toEqual(['a', 'b', 'blur'])
+
+    tree.update()
+    expect(tree.find('Chip').map((chip) => chip.text())).toEqual(['a', 'b', 'blur'])
   })
 })
 


### PR DESCRIPTION
I found a bug that lead to the `onChange` callback being called with the same value appended twice (So `["a", "b", "new", "new"]`). This happens if the `setState` call is resolved synchronously. Fixed it & added a test.

I also adapted the test to use enzyme's `update` function. Before that the dom expectation would not lead to the test failing (the `setTimeout` callback was never called due to the timers being mocked out)
