### PR TITLE
Add `delayBeforeAdd` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ import ChipInput from 'material-ui-chip-input'
 |dataSource|`array`||Data source for auto complete. This should be an array of strings or objects.|
 |dataSourceConfig|`shape`||Config for objects list dataSource, e.g. `{ text: 'text', value: 'value' }`. If not specified, the `dataSource` must be a flat array of strings or a custom `chipRenderer` must be set to handle the objects.|
 |defaultValue|`array`||The chips to display by default (for uncontrolled mode).|
-|disabled|`bool`||Disables the chip input if set to true.|
 |delayBeforeAdd|`bool`|`false`|Use `setTimeout` 150ms delay before adding chips in case other input callbacks like `onSelection` need to fire first.|
+|disabled|`bool`||Disables the chip input if set to true.|
 |FormHelperTextProps|`object`||Props to pass through to the `FormHelperText` component.|
 |fullWidth|`bool`||If true, the chip input will fill the available width.|
 |fullWidthInput|`bool`||If true, the input field will always be below the chips and fill the available space. By default, it will try to be beside the chips.|

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import ChipInput from 'material-ui-chip-input'
 |dataSourceConfig|`shape`||Config for objects list dataSource, e.g. `{ text: 'text', value: 'value' }`. If not specified, the `dataSource` must be a flat array of strings or a custom `chipRenderer` must be set to handle the objects.|
 |defaultValue|`array`||The chips to display by default (for uncontrolled mode).|
 |disabled|`bool`||Disables the chip input if set to true.|
+|delayBeforeAdd|`bool`|`false`|Use `setTimeout` 150ms delay before adding chips in case other input callbacks like `onSelection` need to fire first.|
 |FormHelperTextProps|`object`||Props to pass through to the `FormHelperText` component.|
 |fullWidth|`bool`||If true, the chip input will fill the available width.|
 |fullWidthInput|`bool`||If true, the input field will always be below the chips and fill the available space. By default, it will try to be beside the chips.|

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -233,7 +233,7 @@ class ChipInput extends React.Component {
     const value = event.target.value
     switch (this.props.blurBehavior) {
       case 'add':
-        if (this.props.delayBeforeAdd === true) {
+        if (this.props.delayBeforeAdd) {
           // Lets assume that we only want to add the existing content as chip, when
           // another event has not added a chip within 200ms .
           // e.g. onSelection Callback in Autocomplete case

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -453,10 +453,10 @@ class ChipInput extends React.Component {
       classes,
       className,
       clearInputValueOnChange,
-      defaultValue,
-      delayBeforeAdd,
       dataSource,
       dataSourceConfig,
+      defaultValue,
+      delayBeforeAdd,
       disabled,
       disableUnderline,
       error,
@@ -627,12 +627,12 @@ ChipInput.propTypes = {
   }),
   /** The chips to display by default (for uncontrolled mode). */
   defaultValue: PropTypes.array,
+  /** Whether to use `setTimeout` to delay adding chips in case other input events like `onSelection` need to fire first */
+  delayBeforeAdd: PropTypes.bool,
   /** Disables the chip input if set to true. */
   disabled: PropTypes.bool,
   /** Disable the input underline. Only valid for 'standard' variant */
   disableUnderline: PropTypes.bool,
-  /** Whether to use `setTimeout` to delay adding chips in case other input events like `onSelection` need to fire first */
-  delayBeforeAdd: PropTypes.bool,
   /** Props to pass through to the `FormHelperText` component. */
   FormHelperTextProps: PropTypes.object,
   /** If true, the chip input will fill the available width. */
@@ -675,8 +675,8 @@ ChipInput.defaultProps = {
   allowDuplicates: false,
   blurBehavior: 'clear',
   clearInputValueOnChange: false,
-  disableUnderline: false,
   delayBeforeAdd: false,
+  disableUnderline: false,
   newChipKeyCodes: [13],
   variant: 'standard'
 }

--- a/src/ChipInput.spec.js
+++ b/src/ChipInput.spec.js
@@ -131,9 +131,9 @@ describe('uncontrolled mode', () => {
     tree.find('input').getDOMNode().value = 'foo'
     tree.find('input').simulate('change', { target: tree.find('input').getDOMNode() })
     expect(handleUpdateInput).toBeCalledWith(
-     expect.objectContaining({
-       target: expect.anything()
-     })
+      expect.objectContaining({
+        target: expect.anything()
+      })
     )
   })
 })
@@ -392,7 +392,27 @@ describe('blurBehavior modes', () => {
     expect(tree.find('input').getDOMNode().value).toBe('foo')
   })
 
-  it('adds the input on blur with blurBehavior set to add', () => {
+  it('adds the input on blur with blurBehavior set to add with timeout', () => {
+    const handleChange = jest.fn()
+    jest.useFakeTimers()
+    const tree = mount(
+      <ChipInput defaultValue={['a', 'b']} blurBehavior='add' delayBeforeAdd onChange={handleChange} />
+    )
+    tree.find('input').getDOMNode().value = 'blur'
+    tree.find('input').simulate('blur')
+
+    jest.runAllTimers()
+
+    expect(tree.find('input').getDOMNode().value).toBe('')
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+
+    expect(handleChange.mock.calls[0][0]).toEqual(['a', 'b', 'blur'])
+
+    tree.update()
+    expect(tree.find('Chip').map((chip) => chip.text())).toEqual(['a', 'b', 'blur'])
+  })
+
+  it('adds the input on blur with blurBehavior set to add without timeout', () => {
     const handleChange = jest.fn()
     jest.useFakeTimers()
     const tree = mount(
@@ -404,7 +424,7 @@ describe('blurBehavior modes', () => {
     jest.runAllTimers()
 
     expect(tree.find('input').getDOMNode().value).toBe('')
-    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenCalledTimes(0)
 
     expect(handleChange.mock.calls[0][0]).toEqual(['a', 'b', 'blur'])
 
@@ -500,7 +520,7 @@ describe('keys', () => {
       metaKey: false,
       ctrlKey: false,
       altKey: false,
-      target: {value: 'non-empty'},
+      target: { value: 'non-empty' },
       preventDefault: () => {
         prevented = true
       }

--- a/src/__snapshots__/ChipInput.spec.js.snap
+++ b/src/__snapshots__/ChipInput.spec.js.snap
@@ -40,6 +40,7 @@ exports[`uncontrolled mode matches the snapshot 1`] = `
         "bar",
       ]
     }
+    delayBeforeAdd={false}
     disableUnderline={false}
     newChipKeyCodes={
       Array [

--- a/stories/examples/react-autosuggest.js
+++ b/stories/examples/react-autosuggest.js
@@ -58,7 +58,7 @@ function renderInput (inputProps) {
       value={chips}
       inputRef={ref}
       {...other}
-  />
+    />
   )
 }
 
@@ -183,7 +183,7 @@ class ReactAutosuggestExample extends React.Component {
   handleDeleteChip (chip, index) {
     let temp = this.state.value
     temp.splice(index, 1)
-    this.setState({value: temp})
+    this.setState({ value: temp })
   }
 
   render () {
@@ -204,7 +204,7 @@ class ReactAutosuggestExample extends React.Component {
         renderSuggestionsContainer={renderSuggestionsContainer}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
-        onSuggestionSelected={(e, {suggestionValue}) => { this.handleAddChip(suggestionValue); e.preventDefault() }}
+        onSuggestionSelected={(e, { suggestionValue }) => { this.handleAddChip(suggestionValue); e.preventDefault() }}
         focusInputOnSuggestionClick={false}
         inputProps={{
           classes,
@@ -259,12 +259,12 @@ class ReactAutosuggestRemoteExample extends React.Component {
   };
 
   handleAddChip (chip) {
-    this.setState({value: this.state.value.concat([chip])})
+    this.setState({ value: this.state.value.concat([chip]) })
   }
   handleDeleteChip (chip, index) {
     let temp = this.state.value
     temp.splice(index, 1)
-    this.setState({value: temp})
+    this.setState({ value: temp })
   }
 
   render () {
@@ -285,7 +285,7 @@ class ReactAutosuggestRemoteExample extends React.Component {
         renderSuggestionsContainer={renderSuggestionsContainer}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
-        onSuggestionSelected={(e, {suggestionValue}) => { this.handleAddChip(suggestionValue); e.preventDefault() }}
+        onSuggestionSelected={(e, { suggestionValue }) => { this.handleAddChip(suggestionValue); e.preventDefault() }}
         focusInputOnSuggestionClick={false}
         inputProps={{
           classes,


### PR DESCRIPTION
Fixes #262 by adding an explicit `delayBeforeAdd` option in order to disable use of `setTimeout` by default. This could be a breaking change for those who are using event callbacks that conflict with `onBlur`. However, I assume that is the edge case and most implementations can use `onBlur` just fine.

@leMaik you OK with disabling the delay by default?