### PR TITLE
Set *classes* property to optional in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,7 +29,7 @@ export interface Props extends Omit<FormControlProps, 'onChange'> {
   alwaysShowPlaceholder?: boolean;
   blurBehavior?: 'clear' | 'add' | 'ignore';
   chipRenderer?: ChipRenderer;
-  classes: Record<string, string>;
+  classes?: Record<string, string>;
   clearInputValueOnChange?: boolean;
   dataSource?: any[];
   dataSourceConfig?: {


### PR DESCRIPTION
Changed *classes* prop to optional in typings to optional as it is not required while using in production.

Closes #273 