### PR TITLE
Fix ClassKey inference for outlined and filled variants

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { FormControlProps } from '@material-ui/core/FormControl';
 import { FormHelperTextProps } from '@material-ui/core/FormHelperText';
-import { InputProps } from '@material-ui/core/Input';
+import { InputProps as StandardInputProps } from '@material-ui/core/Input';
+import { FilledInputProps } from '@material-ui/core/FilledInput';
+import { OutlinedInputProps } from '@material-ui/core/OutlinedInput';
 import { InputLabelProps } from '@material-ui/core/InputLabel';
 
 export interface ChipRendererArgs {
@@ -24,7 +26,7 @@ export type ChipRenderer = (
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 // omitting onChange from FormControlProps as we use a custom onChange
-export interface Props extends Omit<FormControlProps, 'onChange'> {
+export interface BaseTextFieldProps extends Omit<FormControlProps, 'onChange'> {
   allowDuplicates?: boolean;
   alwaysShowPlaceholder?: boolean;
   blurBehavior?: 'clear' | 'add' | 'ignore';
@@ -44,7 +46,6 @@ export interface Props extends Omit<FormControlProps, 'onChange'> {
   fullWidthInput?: boolean;
   helperText?: React.ReactNode;
   InputLabelProps?: InputLabelProps;
-  InputProps?: InputProps;
   inputRef?: (ref: React.Ref<HTMLInputElement>) => any;
   inputValue?: string;
   label?: React.ReactNode;
@@ -52,12 +53,29 @@ export interface Props extends Omit<FormControlProps, 'onChange'> {
   onAdd?: (chip: any) => any;
   onBeforeAdd?: (chip: any) => boolean;
   onChange?: (chips: any[]) => any;
-  onDelete?: (chip:any, index: number) => any;
+  onDelete?: (chip: any, index: number) => any;
   onUpdateInput?: React.EventHandler<any>;
   placeholder?: string;
   value?: any[];
   variant?: 'outlined' | 'standard' | 'filled';
 }
+
+export interface StandardTextFieldProps extends BaseTextFieldProps {
+  variant?: 'standard';
+  InputProps?: Partial<StandardInputProps>;
+}
+
+export interface FilledTextFieldProps extends BaseTextFieldProps {
+  variant: 'filled';
+  InputProps?: Partial<FilledInputProps>;
+}
+
+export interface OutlinedTextFieldProps extends BaseTextFieldProps {
+  variant: 'outlined';
+  InputProps?: Partial<OutlinedInputProps>;
+}
+
+export type Props = StandardTextFieldProps | FilledTextFieldProps | OutlinedTextFieldProps;
 
 declare const ChipInput: React.ComponentType<Props>;
 export default ChipInput;


### PR DESCRIPTION
This merge request fixes problem described in https://github.com/mui-org/material-ui/issues/12999 and https://github.com/mui-org/material-ui/issues/13099.

Fixed the same way as in the official Material-UI code: https://github.com/mui-org/material-ui/pull/13060