### PR TITLE
Removed negative margin on FormHelperText

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -104,9 +104,7 @@ const styles = (theme) => {
     labelShrink: {
       top: 0
     },
-    helperText: {
-      marginBottom: -20
-    },
+    helperText: {},
     focused: {},
     disabled: {},
     underline: {


### PR DESCRIPTION
A negative margin is not how the official TextField handles the FormHelperText, so it shouldn't be baked into this style here.

Fixes #266