### PR TITLE
Fix 'required' prop for non-empty chip sets.

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -576,7 +576,7 @@ class ChipInput extends React.Component {
           [classes.marginDense]: other.margin === 'dense'
         })}
         error={error}
-        required={required}
+        required={chips.length ? undefined : required}
         onClick={this.focus}
         disabled={disabled}
         variant={variant}
@@ -590,6 +590,7 @@ class ChipInput extends React.Component {
             focused={this.state.isFocused}
             variant={variant}
             ref={this.labelRef}
+            required={required}
             {...InputLabelProps}
           >
             {label}

--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -576,7 +576,7 @@ class ChipInput extends React.Component {
           [classes.marginDense]: other.margin === 'dense'
         })}
         error={error}
-        required={chips.length ? undefined : required}
+        required={chips.length > 0 ? undefined : required}
         onClick={this.focus}
         disabled={disabled}
         variant={variant}


### PR DESCRIPTION
The `required` prop triggers undesired validation errors when chips are entered, since the FormControl context tells the input field that text input is required for submission.

![Screen Shot 2020-04-22 at 2 28 27 PM](https://user-images.githubusercontent.com/13558253/80021685-e20b8780-84a8-11ea-869c-b3ff868688ea.png)


This change sets the FormControl's `required` state only when the list of chips is empty. To make sure the asterisk always appears when desired, I'm passing the `required` prop to the `InputLabel` component.