### PR TITLE
Fixed Storybook autocomplete example

### DIFF
--- a/stories/examples/react-autosuggest.js
+++ b/stories/examples/react-autosuggest.js
@@ -210,7 +210,7 @@ class ReactAutosuggest extends React.Component {
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         onSuggestionSelected={(e, { suggestionValue }) => { this.handleAddChip(suggestionValue); e.preventDefault() }}
-        focusInputOnSuggestionClick={false}
+        focusInputOnSuggestionClick
         inputProps={{
           chips: this.state.value,
           value: this.state.textFieldInput,


### PR DESCRIPTION
Hi, 

I noticed that with the "react-autosuggest" Storybook example I could not get it to add anything past the first chip unless I blurred and then focused the input. 

It seems this issue was fixed in a previous commit 1380b3e024f2954e796bd63bcd5429fd8cf5c3ba  but only for the remote example .

This pull request should hopefully fix that.

Thanks,
Stephen