### PR TITLE
added peerdependency @material-ui/core:4.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "standard": "^13.1.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^1.0.0 || ^3.1.0",
+    "@material-ui/core": "^1.0.0 || ^3.1.0 || ^4.11.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },


### PR DESCRIPTION
it seems to work fine with added peerdependency @material-ui/core:4.11.0, so add it get rid of npm warning