### PR TITLE
Issue with `onAdd` not triggering when the initial `value` is empty.

### DIFF
--- a/src/ChipInput.js
+++ b/src/ChipInput.js
@@ -413,7 +413,7 @@ class ChipInput extends React.Component {
       }
 
       if (this.props.allowDuplicates || !chips.some((c) => c[this.props.dataSourceConfig.value] === chip[this.props.dataSourceConfig.value])) {
-        if (this.props.value && this.props.onAdd) {
+        if (this.props.onAdd) {
           this.props.onAdd(chip)
         } else {
           this.updateChips([...this.state.chips, chip])
@@ -424,7 +424,7 @@ class ChipInput extends React.Component {
 
     if (chip.trim().length > 0) {
       if (this.props.allowDuplicates || chips.indexOf(chip) === -1) {
-        if (this.props.value && this.props.onAdd) {
+        if (this.props.onAdd) {
           this.props.onAdd(chip)
         } else {
           this.updateChips([...this.state.chips, chip])


### PR DESCRIPTION
So when the component renders without any value, the `onAdd` is not triggering, making it impossible to trigger `onAdd` without having an initial array of at least 1 item.

I also don't see any reason why you would want to check for `this.props.value` in these places..